### PR TITLE
Fix icon hover shadow to match icon shapes

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -37,32 +37,32 @@ const Header: NextPage = () => {
 
           <nav className='flex items-center gap-3'>
             <Link href={Config.github} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift' target='_blank' rel='noopener noreferrer'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon' target='_blank' rel='noopener noreferrer'>
                 <BsGithub className='text-xl' />
               </a>
             </Link>
             <Link href={Config.youtube} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift' target='_blank' rel='noopener noreferrer'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon' target='_blank' rel='noopener noreferrer'>
                 <BsYoutube className='text-xl' />
               </a>
             </Link>
             <Link href={Config.medium} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift' target='_blank' rel='noopener noreferrer'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon' target='_blank' rel='noopener noreferrer'>
                 <SiMedium className='text-xl' />
               </a>
             </Link>
             <Link href={`mailto:${Config.staffMail}`} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon'>
                 <AiOutlineMail className='text-xl' />
               </a>
             </Link>
             <Link href={'https://include-kaist.notion.site/'} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift' target='_blank' rel='noopener noreferrer'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon' target='_blank' rel='noopener noreferrer'>
                 <SiNotion className='text-xl' />
               </a>
             </Link>
             <Link href={'https://www.instagram.com/include_kaist/'} passHref>
-              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift' target='_blank' rel='noopener noreferrer'>
+              <a className='p-2 text-accent hover:text-gray-600 transition-colors duration-200 hover-lift-icon' target='_blank' rel='noopener noreferrer'>
                 <BsInstagram className='text-xl' />
               </a>
             </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -74,6 +74,14 @@
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
   }
+
+  .hover-lift-icon {
+    transition: transform 0.2s ease, filter 0.2s ease;
+  }
+  .hover-lift-icon:hover {
+    transform: translateY(-2px);
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15));
+  }
   
   .btn-primary {
     @apply bg-accent text-white px-6 py-3 rounded-lg font-semibold tracking-wide;


### PR DESCRIPTION
Replace rectangular box-shadow with drop-shadow filter for social media
icons in header. The new hover-lift-icon class uses CSS filter drop-shadow
which follows the actual SVG icon shapes instead of creating a rectangular
shadow around the link element.

Changes:
- Add new .hover-lift-icon class in globals.css using filter: drop-shadow()
- Update all social media icon links in header.tsx to use hover-lift-icon
- Keep original .hover-lift class for buttons and other elements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines hover effect for social icons to match SVG shapes.
> 
> - Adds `hover-lift-icon` in `globals.css` using `filter: drop-shadow()` with lift on hover
> - Updates social icon links in `header.tsx` to use `hover-lift-icon` instead of `hover-lift`
> - Keeps existing `hover-lift` class for non-icon elements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9526f938aa2da27e7ac1e2840d0c53b84a573d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->